### PR TITLE
feat: implement external hyperlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test.py
 cat.jpeg
 *.docx
 *.pdf
+test_functionality

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Key differences at a glance:
 - Supporting floating images within documents
 - Supporting the ability to transform word documents into PDF's
 - Horizontal rules + paragraph bounding boxes
+- External hyperlinks
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skelmis-docx"
-version = "1.5.0"
+version = "1.6.0"
 description = "Create, read, and update Microsoft Word .docx files."
 authors = ["Skelmis <skelmis.craft@gmail.com>"]
 license = "MIT"

--- a/src/docx/__init__.py
+++ b/src/docx/__init__.py
@@ -13,7 +13,7 @@ from docx.api import Document
 if TYPE_CHECKING:
     from docx.opc.part import Part
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 
 __all__ = ["Document"]

--- a/src/docx/text/paragraph.py
+++ b/src/docx/text/paragraph.py
@@ -37,7 +37,7 @@ class Paragraph(StoryChild):
         *,
         color: str | None = "0000FF",
         underline: bool = True,
-    ) -> OxmlElement:
+    ) -> Hyperlink:
         """
         A function that places an external hyperlink within a paragraph object.
 
@@ -47,7 +47,7 @@ class Paragraph(StoryChild):
         :param text: The text displayed for the url
         :param color: The color of the text displayed
         :param underline: Whether the text is underlined or not
-        :return: The hyperlink object. If you want the full object consider .hyperlinks
+        :return: The hyperlink object.
         """
         # Sourced from https://github.com/python-openxml/python-docx/issues/74#issuecomment-261169410
 
@@ -89,7 +89,7 @@ class Paragraph(StoryChild):
         hyperlink.append(new_run)
 
         self._p.append(hyperlink)
-        return hyperlink
+        return Hyperlink(hyperlink, self)
 
     def insert_horizontal_rule(self):
         """Insert a horizontal rule at the bottom of the current paragraph."""

--- a/src/docx/text/paragraph.py
+++ b/src/docx/text/paragraph.py
@@ -14,6 +14,7 @@ from docx.text.hyperlink import Hyperlink
 from docx.text.pagebreak import RenderedPageBreak
 from docx.text.parfmt import ParagraphFormat
 from docx.text.run import Run
+from docx.opc.constants import RELATIONSHIP_TYPE
 
 if TYPE_CHECKING:
     import docx.types as t
@@ -28,6 +29,67 @@ class Paragraph(StoryChild):
     def __init__(self, p: CT_P, parent: t.ProvidesStoryPart):
         super(Paragraph, self).__init__(parent)
         self._p = self._element = p
+
+    def add_external_hyperlink(
+        self,
+        url: str,
+        text: str,
+        *,
+        color: str | None = "0000FF",
+        underline: bool = True,
+    ) -> OxmlElement:
+        """
+        A function that places an external hyperlink within a paragraph object.
+
+        Default behaviour is Blue with underlined text.
+
+        :param url: A string containing the required url
+        :param text: The text displayed for the url
+        :param color: The color of the text displayed
+        :param underline: Whether the text is underlined or not
+        :return: The hyperlink object. If you want the full object consider .hyperlinks
+        """
+        # Sourced from https://github.com/python-openxml/python-docx/issues/74#issuecomment-261169410
+
+        # This gets access to the document.xml.rels file and gets a new relation id value
+        part = self.part
+        r_id = part.relate_to(url, RELATIONSHIP_TYPE.HYPERLINK, is_external=True)
+
+        # Create the w:hyperlink tag and add needed values
+        hyperlink = OxmlElement("w:hyperlink")
+        hyperlink.set(
+            qn("r:id"),
+            r_id,
+        )
+
+        # Create a w:r element
+        new_run = OxmlElement("w:r")
+
+        # Create a new w:rPr element
+        rPr = OxmlElement("w:rPr")
+
+        # Add color if it is given
+        if not color is None:
+            c = OxmlElement("w:color")
+            c.set(qn("w:val"), color)
+            rPr.append(c)
+
+        if underline:
+            u = OxmlElement("w:u")
+            u.set(qn("w:val"), "single")
+            rPr.append(u)
+        else:
+            u = OxmlElement("w:u")
+            u.set(qn("w:val"), "none")
+            rPr.append(u)
+
+        # Join all the xml elements together and add the required text to the w:r element
+        new_run.append(rPr)
+        new_run.text = text
+        hyperlink.append(new_run)
+
+        self._p.append(hyperlink)
+        return hyperlink
 
     def insert_horizontal_rule(self):
         """Insert a horizontal rule at the bottom of the current paragraph."""


### PR DESCRIPTION
Implements https://github.com/python-openxml/python-docx/issues/74 but for external hyperlinks only at this stage

Example code:
```py
def main():
    document = docx.Document()
    p: Paragraph = document.add_paragraph()

    # Default highlight
    hyperlink: Hyperlink = p.add_external_hyperlink("https://www.google.com", "Google")
    print(hyperlink, hyperlink.url, hyperlink.text)
    p.add_run(" break ")

    # Orange highlight with no underline
    p.add_external_hyperlink("http://www.google.com", "Google", color="FF8822", underline=False)

    # Highlighting a link in a table cell
    table = document.add_table(rows=1, cols=1)
    table.rows[0].cells[0].paragraphs[-1].add_external_hyperlink(
        "http://www.google.com",
        "Google",
    )

    document.save("hyperlinks.docx")
```