### PR TITLE
fix: hatch builds ignoring the built in docx files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,4 @@ uv.lock
 .python-version
 
 !src/docx/templates/default.docx
-test.py
-cat.jpeg
-*.docx
-*.pdf
 test_functionality

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skelmis-docx"
-version = "2.2.1"
+version = "2.2.2"
 description = "Create, read, and update Microsoft Word .docx files."
 authors = [{ name = "Skelmis", email = "skelmis.craft@gmail.com" }]
 requires-python = ">=3.10"

--- a/src/skelmis/docx/__init__.py
+++ b/src/skelmis/docx/__init__.py
@@ -13,7 +13,7 @@ from skelmis.docx.api import Document
 if TYPE_CHECKING:
     from skelmis.docx.opc.part import Part
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 
 
 __all__ = ["Document"]


### PR DESCRIPTION
Hatch uses `.gitignore` to pick files to include, given a different 'build' dir the `!src/docx/templates/default.docx` rule is ignored and thus all internal docx files shipped are excluded which breaks everything without a provided template file