### PR TITLE
feat: implement support for bookmarks as well as internal hyperlinking

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 Release History
 ---------------
 
+2.3.0 (2025-06-15)
+++++++++++++++++++
+
+* Implement support to add bookmarks in a paragraph
+* Implement support for creating internal hyperlinks to bookmarks
+
 2.2.2 (2025-06-15)
 ++++++++++++++++++
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Key differences at a glance:
 - Supporting the ability to transform word documents into PDF's ([1](https://skelmis-docx.readthedocs.io/en/latest/api/utility.html#skelmis.docx.utility.document_to_pdf))
 - Horizontal rules + paragraph bounding boxes / borders ([1](https://skelmis-docx.readthedocs.io/en/latest/api/text.html#skelmis.docx.text.paragraph.Paragraph.insert_horizontal_rule), [2](https://skelmis-docx.readthedocs.io/en/latest/api/text.html#skelmis.docx.text.paragraph.Paragraph.draw_paragraph_border))
 - External hyperlinks ([1](https://skelmis-docx.readthedocs.io/en/latest/api/text.html#skelmis.docx.text.paragraph.Paragraph.add_external_hyperlink))
+- Internal hyperlinks (Linking to bookmarks) ([1](https://skelmis-docx.readthedocs.io/en/latest/api/text.html#skelmis.docx.text.paragraph.Paragraph.add_internal_hyperlink))
+- Creating bookmarks ([1](https://skelmis-docx.readthedocs.io/en/latest/api/text.html#skelmis.docx.text.paragraph.Paragraph.add_bookmark))
 - The ability to insert a customisable Table of Contents (ToC) ([1](https://skelmis-docx.readthedocs.io/en/latest/api/text.html#skelmis.docx.text.paragraph.Paragraph.insert_table_of_contents))
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skelmis-docx"
-version = "2.2.2"
+version = "2.3.0"
 description = "Create, read, and update Microsoft Word .docx files."
 authors = [{ name = "Skelmis", email = "skelmis.craft@gmail.com" }]
 requires-python = ">=3.10"

--- a/src/skelmis/docx/__init__.py
+++ b/src/skelmis/docx/__init__.py
@@ -13,7 +13,7 @@ from skelmis.docx.api import Document
 if TYPE_CHECKING:
     from skelmis.docx.opc.part import Part
 
-__version__ = "2.2.2"
+__version__ = "2.3.0"
 
 
 __all__ = ["Document"]

--- a/src/skelmis/docx/text/paragraph.py
+++ b/src/skelmis/docx/text/paragraph.py
@@ -33,17 +33,16 @@ class Paragraph(StoryChild):
         super(Paragraph, self).__init__(parent)
         self._p = self._element = p
 
+    # noinspection PyTypeChecker
     def add_internal_hyperlink(
         self,
         bookmark_name: str,
         display_text: str,
-        tool_tip: str | None = None,
     ) -> Hyperlink:
         """Add an internal hyperlink to a bookmark within the document.
 
         :param bookmark_name: The name of the bookmark as provided to ``add_bookmark``.
         :param display_text: The display text to put in the document and associate with this link.
-        :param tool_tip: The text to show on hover. If not set, defaults to ``#bookmark_name``
         """
         hyperlink = OxmlElement("w:hyperlink")
 
@@ -52,18 +51,10 @@ class Paragraph(StoryChild):
             bookmark_name,
         )
 
-        if tool_tip is not None:
-            hyperlink.set(
-                qn("w:tooltip"),
-                tool_tip,
-            )
-
         new_run = OxmlElement("w:r")
-        r_pr = OxmlElement("w:rPr")
-        new_run.append(r_pr)
+        new_run.append(OxmlElement("w:rPr"))
         new_run.text = display_text
         hyperlink.append(new_run)
-        # noinspection PyTypeChecker
         self._p.append(hyperlink)
         return Hyperlink(hyperlink, self)
 
@@ -275,6 +266,7 @@ class Paragraph(StoryChild):
                 # noinspection PyProtectedMember
                 run._r.append(item)
 
+    # noinspection PyTypeChecker
     def add_external_hyperlink(
         self,
         url: str,

--- a/src/skelmis/docx/text/paragraph.py
+++ b/src/skelmis/docx/text/paragraph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Iterator, List, cast
 
 from skelmis.docx.enum.style import WD_STYLE_TYPE
@@ -37,7 +38,7 @@ class Paragraph(StoryChild):
         bookmark_name: str,
         display_text: str,
         tool_tip: str | None = None,
-    ):
+    ) -> Hyperlink:
         """Add an internal hyperlink to a bookmark within the document.
 
         :param bookmark_name: The name of the bookmark as provided to ``add_bookmark``.
@@ -64,6 +65,7 @@ class Paragraph(StoryChild):
         hyperlink.append(new_run)
         # noinspection PyTypeChecker
         self._p.append(hyperlink)
+        return Hyperlink(hyperlink, self)
 
     def add_bookmark(self, name: str, display_text: str | None = None, *, bookmark_id=None):
         """Add a bookmark to the document for later linking to.
@@ -80,7 +82,7 @@ class Paragraph(StoryChild):
         if bookmark_id is None:
             # ID should be unique,
             # so we make an assumption name also is and call it a day
-            bookmark_id = name
+            bookmark_id = re.sub(r"\s+", "_", name)
 
         self._start_bookmark(name, bookmark_id)
 
@@ -90,7 +92,7 @@ class Paragraph(StoryChild):
             # noinspection PyTypeChecker
             self._p.append(text)
 
-        self._end_bookmark(name, bookmark_id)
+        self._end_bookmark(bookmark_id)
 
     def _start_bookmark(self, name: str, bookmark_id):
         """Add's a 'bookmarkStart' entry."""
@@ -101,11 +103,10 @@ class Paragraph(StoryChild):
         # noinspection PyTypeChecker
         self._p.append(start)
 
-    def _end_bookmark(self, name: str, bookmark_id):
+    def _end_bookmark(self, bookmark_id):
         """Add's a 'bookmarkEnd' entry."""
         end = OxmlElement("w:bookmarkEnd")
         end.set(qn("w:id"), bookmark_id)
-        end.set(qn("w:name"), name)
         # noinspection PyTypeChecker
         self._p.append(end)
 


### PR DESCRIPTION
Example code:
```py
from skelmis.docx import Document

doc = Document()
p = doc.add_paragraph()
p.add_internal_hyperlink("bookmark", "goto bookmark")
doc.add_page_break()

p = doc.add_paragraph()
p.add_bookmark(
    "bookmark",
    "hey look its bookmark display text",
)

doc.save("test.docx")
```

Tested:
`add_bookmark`:
- [x] Libre
- [x] OnlyOffice


`add_internal_hyperlink`:
- [x] Libre
- [x] OnlyOffice

Closes #20 

Initial reference implementation taken from various comments on: <https://stackoverflow.com/questions/57586400/how-to-create-bookmarks-in-a-word-document-then-create-internal-hyperlinks-to-t>